### PR TITLE
Changed sdk version to 8

### DIFF
--- a/bobbylite.realmikefacts.tests/bobbylite.realmikefacts.tests.csproj
+++ b/bobbylite.realmikefacts.tests/bobbylite.realmikefacts.tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Attempting to fix failed pipeline step because the sdk of the runner did not match the sdk referenced in the csproj.